### PR TITLE
fix: send about_to_show for root menu when an item with menu is added

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,8 +16,8 @@ use tui_tree_widget::TreeState;
 
 use tokio::sync::broadcast::Receiver;
 
-use crate::Config;
 use crate::wrappers::{FindMenuByUsize, Id, SniState};
+use crate::Config;
 
 pub type BoxStack = Vec<(i32, Rect)>;
 
@@ -37,7 +37,7 @@ pub struct App {
     // index of currently focused sni item
     pub focused_sni: Option<usize>,
     /// items map from system-tray
-    items: Arc<Mutex<HashMap<String, (StatusNotifierItem, Option<TrayMenu>)>>>,
+    pub items: Arc<Mutex<HashMap<String, (StatusNotifierItem, Option<TrayMenu>)>>>,
     pub tray_rx: Mutex<Receiver<Event>>,
 }
 
@@ -56,8 +56,7 @@ impl App {
     }
 
     /// Updating states
-    pub fn update(&mut self, update: Event) {
-        log::info!("UPDATE: {:?}", update);
+    pub fn update(&mut self) {
         //log::debug!("ITEMS NOW: {:?}", self.get_items().unwrap());
         let mut buffer: HashSet<String> = HashSet::default();
         if let Some(items) = self.get_items() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,17 @@ async fn main() -> AppResult<()> {
         tui.draw(&mut app)?;
         tokio::select! {
             Ok(update) = tray_rx.recv() => {
-                app.update(update);
+                log::info!("UPDATE: {:?}", update);
+                if let system_tray::client::Event::Update(dest, system_tray::client::UpdateEvent::Menu(_)) = update {
+                    // the TrayMenu exist means that the menu path must exist, i think.
+                    let menu_path = app.items.lock().unwrap().get(&dest).unwrap().0.menu.clone().unwrap();
+                    let _ = app.client.about_to_show_menuitem(
+                        dest,
+                        menu_path,
+                        0,
+                    ).await.unwrap();
+                }
+                app.update();
             }
 
             Ok(event) = tui.events.next() => {


### PR DESCRIPTION
Some item does not have menu shown if we don't send this, for example xwaylandvideobridge.
nm-applet available wifi menu is also disabled before we send this (menu is shown but enable=false)