### PR TITLE
Minimal height of the item and scrolling

### DIFF
--- a/config_example.toml
+++ b/config_example.toml
@@ -4,6 +4,12 @@ sorting = false
 # max amount of columns in layout
 columns = 3
 
+# minimum height of tray items
+min_height = 4
+
+# whether to show scrollbar
+scrollbar = true
+
 # enable mouse support
 mouse = false
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,8 +27,8 @@ pub type AppResult<T> = std::result::Result<T, Box<dyn error::Error>>;
 #[derive(Debug)]
 pub struct Layout {
     pub rows: Vec<Vec<usize>>,
-    pub last_col: usize
-
+    pub last_col: usize,
+    pub scroll_offset: u16,
 }
 
 impl Layout {
@@ -36,6 +36,7 @@ impl Layout {
         Self {
             rows: Vec::default(),
             last_col: 0,
+            scroll_offset: 0,
         }
     }
 }
@@ -52,6 +53,8 @@ pub struct App {
     pub sni_states: IndexMap<String, SniState>, // for the StatusNotifierItem
     //  currently focused sni item info
     pub focused_sni_index: usize,
+    /// last focused index to detect focus changes for auto-scrolling
+    pub last_focused_sni_index: usize,
     pub focused_sni_key: String,
     /// items map from system-tray
     pub items: Arc<Mutex<HashMap<String, (StatusNotifierItem, Option<TrayMenu>)>>>,
@@ -70,8 +73,9 @@ impl App {
             sni_states: IndexMap::default(),
             client,
             focused_sni_index: 0,
+            last_focused_sni_index: 0,
             focused_sni_key: String::default(),
-            layout: Layout::new()
+            layout: Layout::new(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,12 @@ pub struct Config {
     #[serde(default = "columns")]
     pub columns: usize,
 
+    #[serde(default = "scrollbar")]
+    pub scrollbar: bool,
+
+    #[serde(default = "min_height")]
+    pub min_height: u16,
+
     #[serde(default = "sorting")]
     pub sorting: bool,
 
@@ -144,6 +150,8 @@ impl Default for Config {
             symbols: symbols(),
             colors: colors(),
             columns: columns(),
+            scrollbar: scrollbar(),
+            min_height: min_height(),
             mouse: mouse(),
             key_map: key_map(),
         }
@@ -242,6 +250,14 @@ fn node_no_children_symbol() -> String {
 
 const fn columns() -> usize {
     3
+}
+
+const fn min_height() -> u16 {
+    4
+}
+
+const fn scrollbar() -> bool {
+    true
 }
 
 const fn mouse() -> bool {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -64,18 +64,37 @@ async fn handle_click(mouse_event: MouseEvent, app: &App) -> Option<()> {
     None
 }
 
-fn handle_scroll(mouse_event: MouseEvent, app: &App) -> Option<()> {
-    let mut tree_state = app.get_focused_tree_state_mut()?;
+fn handle_scroll(mouse_event: MouseEvent, app: &mut App) -> Option<()> {
+    let pos = get_pos(mouse_event);
+
+    // If mouse is over focused item, scroll its menu
+    if let Some(sni_state) = app.get_focused_sni_state() {
+        if sni_state.rect.contains(pos) {
+            let mut tree_state = app.get_focused_tree_state_mut()?;
+            match mouse_event.kind {
+                MouseEventKind::ScrollUp => {
+                    tree_state.scroll_up(1);
+                }
+                MouseEventKind::ScrollDown => {
+                    tree_state.scroll_down(1);
+                }
+                _ => {}
+            }
+            return Some(());
+        }
+    }
+
+    // Otherwise scroll the tray layout
     match mouse_event.kind {
         MouseEventKind::ScrollUp => {
-            tree_state.scroll_up(1);
+            app.layout.scroll_offset = app.layout.scroll_offset.saturating_sub(1);
         }
         MouseEventKind::ScrollDown => {
-            tree_state.scroll_down(1);
+            app.layout.scroll_offset = app.layout.scroll_offset.saturating_add(1);
         }
         _ => {}
     }
-    None
+    Some(())
 }
 
 async fn handle_move(mouse_event: MouseEvent, app: &mut App) -> Option<()> {
@@ -88,7 +107,6 @@ async fn handle_move(mouse_event: MouseEvent, app: &mut App) -> Option<()> {
             return None;
         } else {
             sni_state.set_focused(false);
-            app.focused_sni_index = 0;
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2,6 +2,7 @@ use std::iter::repeat_n;
 
 use ratatui::{
     layout::{Constraint, Layout, Rect},
+    widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState},
     Frame,
 };
 
@@ -11,6 +12,64 @@ use crate::wrappers::Item;
 /// Renders the user interface widgets.
 pub fn render(app: &mut App, frame: &mut Frame) {
     let mut rectangles: Vec<Rect> = Vec::default();
+
+    let rows = app.layout.rows.len();
+    if rows == 0 {
+        return;
+    }
+    let min_height = app.config.min_height;
+    let mut area = frame.area();
+
+    let total_min_height = rows as u16 * min_height;
+
+    // Split area for scrollbar only if enabled AND needed
+    let scrollbar_area = if app.config.scrollbar && total_min_height > area.height {
+        let [main, scrollbar] =
+            Layout::horizontal([Constraint::Fill(1), Constraint::Length(1)]).areas(area);
+        area = main;
+        Some(scrollbar)
+    } else {
+        None
+    };
+
+    let viewport_height = area.height;
+    let max_scroll = total_min_height.saturating_sub(viewport_height);
+
+    // Calculate scroll offset to keep focused item visible only if focus changed
+    if app.focused_sni_index != app.last_focused_sni_index {
+        let focused_row = app
+            .layout
+            .rows
+            .iter()
+            .position(|row| row.contains(&app.focused_sni_index))
+            .unwrap_or(0);
+        let row_top = focused_row as u16 * min_height;
+        let row_bottom = row_top + min_height;
+
+        if row_top < app.layout.scroll_offset {
+            app.layout.scroll_offset = row_top;
+        } else if row_bottom > app.layout.scroll_offset + viewport_height {
+            app.layout.scroll_offset = row_bottom.saturating_sub(viewport_height);
+            // Snap to row boundary when auto-scrolling down
+            app.layout.scroll_offset = (app.layout.scroll_offset / min_height) * min_height;
+            if app.layout.scroll_offset + viewport_height < row_bottom {
+                 app.layout.scroll_offset = app.layout.scroll_offset.saturating_add(min_height).min(max_scroll);
+            }
+        }
+        app.last_focused_sni_index = app.focused_sni_index;
+    }
+
+    app.layout.scroll_offset = app.layout.scroll_offset.min(max_scroll);
+
+    // Render scrollbar if needed
+    if let Some(sa) = scrollbar_area {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
+        let mut state = ScrollbarState::new(total_min_height as usize)
+            .position(app.layout.scroll_offset as usize)
+            .viewport_content_length(viewport_height as usize);
+        frame.render_stateful_widget(scrollbar, sa, &mut state);
+    }
+
     if let Some(items) = app.get_items() {
         let mut items_vec: Vec<Item> = Vec::new();
         app.sni_states.iter().for_each(|(k, v)| {
@@ -21,24 +80,49 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         });
 
         rectangles = {
-            let size = items_vec.len();
-            let columns: usize = app.config.columns;
-            let rows: usize = (size + columns - 1) / columns;
-
             let mut result = Vec::new();
 
+            // If we are scrolling, we split an area equal to the total minimum height.
+            // If not, we split the viewport so they can expand.
+            let split_area = if total_min_height > viewport_height {
+                Rect::new(area.x, area.y, area.width, total_min_height)
+            } else {
+                area
+            };
+
             let row_layout =
-                Layout::vertical(repeat_n(Constraint::Fill(1), rows)).split(frame.area());
+                Layout::vertical(repeat_n(Constraint::Min(min_height), rows)).split(split_area);
 
             for r in 0..rows {
-                let start = r * columns;
-                let end = (start + columns).min(size);
-                let items_n = end - start;
+                let items_n = app.layout.rows[r].len();
 
                 let col_layout =
                     Layout::horizontal(repeat_n(Constraint::Fill(1), items_n)).split(row_layout[r]);
 
-                result.extend_from_slice(&col_layout[..items_n]);
+                // Culling
+                for col_rect in col_layout.iter().copied() {
+                    let abs_y = col_rect.y;
+                    let scroll_y = app.layout.scroll_offset;
+
+                    if abs_y + col_rect.height <= scroll_y || abs_y >= scroll_y + viewport_height {
+                        // Fully outside the viewport
+                        result.push(Rect::default());
+                    } else {
+                        // Partially or fully inside
+                        let mut r = col_rect;
+                        let y_offset = abs_y as i32 - scroll_y as i32;
+
+                        if y_offset < 0 {
+                             // Item is partially above the top
+                             r.y = area.y;
+                             r.height = (abs_y + col_rect.height).saturating_sub(scroll_y);
+                        } else {
+                             // Item is below or at the top
+                             r.y = area.y + y_offset as u16;
+                        }
+                        result.push(r.intersection(area));
+                    }
+                }
             }
 
             result


### PR DESCRIPTION
- Adds minimal height config setting for tray menus, which is respected in the layout
- If layout can't fit menus according to the set minimal_height, it handles scrolling. 
- Optional scrollbar (a way to scroll with a mouse)

solves #15 